### PR TITLE
Add FieldMaskParser::Parser::DeepHashNode#to_h

### DIFF
--- a/lib/field_mask_parser/parser/deep_hash_node.rb
+++ b/lib/field_mask_parser/parser/deep_hash_node.rb
@@ -20,6 +20,12 @@ module FieldMaskParser
       def ==(other)
         is_leaf == other.is_leaf && children == other.children
       end
+
+      def to_h
+        @children.map do |field, child|
+          [field, child.to_h]
+        end.to_h
+      end
     end
   end
 end


### PR DESCRIPTION
## WHY
Sometimes we want to use `Add FieldMaskParser::Parser::DeepHashNode#to_h`

## WHAT
Add `FieldMaskParser::Parser::DeepHashNode#to_h`