### PR TITLE
Add has_ones and has_manies

### DIFF
--- a/lib/field_mask_parser/dispatcher/active_record_dispatcher.rb
+++ b/lib/field_mask_parser/dispatcher/active_record_dispatcher.rb
@@ -7,8 +7,15 @@ module FieldMaskParser
       def dispatch(klass, name)
         if klass.attribute_names.include?(name.to_s)
           Type::ATTRIBUTE
-        elsif klass.reflect_on_association(name)
-          Type::ASSOCIATION
+        elsif (assoc = klass.reflect_on_association(name))
+          case assoc
+          when ActiveRecord::Reflection::HasOneReflection
+            Type::HAS_ONE
+          when ActiveRecord::Reflection::HasManyReflection
+            Type::HAS_MANY
+          else
+            raise "invalid association!"
+          end
         else
           Type::UNKNOWN
         end

--- a/lib/field_mask_parser/dispatcher/type.rb
+++ b/lib/field_mask_parser/dispatcher/type.rb
@@ -6,9 +6,10 @@ module FieldMaskParser
         @type = type
       end
 
-      ATTRIBUTE   = self.new("Dispatcher::Type::ATTRIBUTE")
-      ASSOCIATION = self.new("Dispatcher::Type::ASSOCIATION")
-      UNKNOWN     = self.new("Dispatcher::Type::UNKNOWN")
+      ATTRIBUTE = self.new("Dispatcher::Type::ATTRIBUTE")
+      HAS_ONE   = self.new("Dispatcher::Type::HAS_ONE")
+      HAS_MANY  = self.new("Dispatcher::Type::HAS_MANY")
+      UNKNOWN   = self.new("Dispatcher::Type::UNKNOWN")
     end
   end
 end

--- a/lib/field_mask_parser/node.rb
+++ b/lib/field_mask_parser/node.rb
@@ -1,18 +1,17 @@
 module FieldMaskParser
   class Node
-    attr_reader :name, :is_leaf, :klass, :attrs, :assocs
+    attr_reader :name, :is_leaf, :klass, :attrs, :has_ones, :has_manies
 
     # @param [Symbol | NilClass] name nil when being top-level node
     # @param [bool] is_leaf
-    # @param [<Symbol>] attrs
-    # @param [Set<Node>] assocs
     # @param [ActiveRecord::Base] klass
     def initialize(name:, is_leaf:, klass:)
-      @name    = name
-      @is_leaf = is_leaf
-      @klass   = klass
-      @attrs   = []
-      @assocs  = []
+      @name       = name
+      @is_leaf    = is_leaf
+      @klass      = klass
+      @attrs      = []
+      @has_ones   = []
+      @has_manies = []
     end
 
     # @param [Symbol] f
@@ -21,17 +20,23 @@ module FieldMaskParser
     end
 
     # @param [Node] n
-    def push_assoc(n)
-      @assocs.push(n)
+    def push_has_one(n)
+      @has_ones.push(n)
+    end
+
+    # @param [Node] n
+    def push_has_many(n)
+      @has_manies.push(n)
     end
 
     def to_h
       {
-        name:    @name,
-        is_leaf: @is_leaf,
-        klass:   @klass,
-        attrs:   @attrs,
-        assocs:  @assocs.map(&:to_h)
+        name:       @name,
+        is_leaf:    @is_leaf,
+        klass:      @klass,
+        attrs:      @attrs,
+        has_ones:   @has_ones.map(&:to_h),
+        has_manies: @has_manies.map(&:to_h),
       }
     end
   end

--- a/spec/field_mask_parser_spec.rb
+++ b/spec/field_mask_parser_spec.rb
@@ -11,6 +11,7 @@ describe FieldMaskParser do
       end
 
       has_one :profile
+      has_many :items
     end
 
     class Profile < ActiveRecord::Base
@@ -23,67 +24,112 @@ describe FieldMaskParser do
       belongs_to :user
     end
 
+    class Item < ActiveRecord::Base
+      class << self
+        def attribute_names
+          ["id", "type"]
+        end
+      end
+
+      belongs_to :user
+    end
+
     it "parses paths and generates node" do
       expect(FieldMaskParser.parse(paths: [""], root: User).to_h).to eq({
-        name:    nil,
-        is_leaf: false,
-        klass:   User,
-        attrs:   [],
-        assocs:  [],
+        name:       nil,
+        is_leaf:    false,
+        klass:      User,
+        attrs:      [],
+        has_ones:   [],
+        has_manies: [],
       })
 
       expect(FieldMaskParser.parse(paths: ["id"], root: User).to_h).to eq({
-        name:    nil,
-        is_leaf: false,
-        klass:   User,
-        attrs:   [:id],
-        assocs:  [],
+        name:       nil,
+        is_leaf:    false,
+        klass:      User,
+        attrs:      [:id],
+        has_ones:   [],
+        has_manies: [],
       })
 
       expect(FieldMaskParser.parse(paths: ["id", "profile.name"], root: User).to_h).to eq({
-        name:    nil,
-        is_leaf: false,
-        klass:   User,
-        attrs:   [:id],
-        assocs:  [
+        name:       nil,
+        is_leaf:    false,
+        klass:      User,
+        attrs:      [:id],
+        has_ones:   [
           {
-            name:    :profile,
-            is_leaf: false,
-            klass:   Profile,
-            attrs:   [:name],
-            assocs:  [],
+            name:       :profile,
+            is_leaf:    false,
+            klass:      Profile,
+            attrs:      [:name],
+            has_ones:   [],
+            has_manies: [],
           }
         ],
+        has_manies: [],
       })
 
       expect(FieldMaskParser.parse(paths: ["id", "profile"], root: User).to_h).to eq({
-        name:    nil,
-        is_leaf: false,
-        klass:   User,
-        attrs:   [:id],
-        assocs:  [
+        name:        nil,
+        is_leaf:     false,
+        klass:       User,
+        attrs:       [:id],
+        has_ones:    [
           {
-            name:    :profile,
-            is_leaf: true,
-            klass:   Profile,
-            attrs:   [],
-            assocs:  [],
+            name:       :profile,
+            is_leaf:    true,
+            klass:      Profile,
+            attrs:      [],
+            has_ones:   [],
+            has_manies: [],
           }
         ],
+        has_manies: [],
       })
 
       expect(FieldMaskParser.parse(paths: ["id", "profile", "profile.name"], root: User).to_h).to eq({
-        name:    nil,
-        is_leaf: false,
-        klass:   User,
-        attrs:   [:id],
-        assocs:  [
+        name:        nil,
+        is_leaf:     false,
+        klass:       User,
+        attrs:       [:id],
+        has_ones:    [
           {
-            name:    :profile,
-            is_leaf: true,
-            klass:   Profile,
-            attrs:   [:name],
-            assocs:  [],
+            name:       :profile,
+            is_leaf:    true,
+            klass:      Profile,
+            attrs:      [:name],
+            has_ones:   [],
+            has_manies: [],
+          }
+        ],
+        has_manies:  [],
+      })
+
+      expect(FieldMaskParser.parse(paths: ["id", "profile", "profile.name", "items.type"], root: User).to_h).to eq({
+        name:        nil,
+        is_leaf:     false,
+        klass:       User,
+        attrs:       [:id],
+        has_ones:    [
+          {
+            name:       :profile,
+            is_leaf:    true,
+            klass:      Profile,
+            attrs:      [:name],
+            has_ones:   [],
+            has_manies: [],
+          }
+        ],
+        has_manies:  [
+          {
+            name:       :items,
+            is_leaf:    false,
+            klass:      Item,
+            attrs:      [:type],
+            has_ones:   [],
+            has_manies: [],
           }
         ],
       })


### PR DESCRIPTION
## WHY
We want to distinguish has_one association and has_many association.

## WHAT
Add `#has_ones` and `#has_manies` to `FieldMaskParser::Node`.