### PR TITLE
Add Node#assocs

### DIFF
--- a/lib/field_mask_parser/node.rb
+++ b/lib/field_mask_parser/node.rb
@@ -29,6 +29,10 @@ module FieldMaskParser
       @has_manies.push(n)
     end
 
+    def assocs
+      has_ones + has_manies
+    end
+
     def to_h
       {
         name:       @name,


### PR DESCRIPTION
## WHY
Sometimes we want to use `Node#assocs`

## WHAT
Add `Node#assocs`