### PR TITLE
Add #== to FieldMaskParser::Node

### DIFF
--- a/lib/field_mask_parser/node.rb
+++ b/lib/field_mask_parser/node.rb
@@ -55,5 +55,10 @@ module FieldMaskParser
       r.sort! if sort
       r
     end
+
+    def ==(other)
+      self.class == other.class &&
+        self.to_paths == other.to_paths
+    end
   end
 end

--- a/spec/field_mask_parser/node_spec.rb
+++ b/spec/field_mask_parser/node_spec.rb
@@ -25,4 +25,36 @@ describe FieldMaskParser do
       ]
     end
   end
+
+  describe "#==" do
+    it "returns equality" do
+      node = FieldMaskParser.parse(
+        paths: [
+          "id",
+          "profile.id",
+        ],
+        root: User
+      )
+      expect(node).to eq node
+
+      node2 = FieldMaskParser.parse(
+        paths: [
+          "id",
+          "profile.id",
+        ],
+        root: User
+      )
+      expect(node).to eq node2
+
+      node3 = FieldMaskParser.parse(
+        paths: [
+          "id",
+        ],
+        root: User
+      )
+      expect(node).not_to eq node3
+
+      expect(node).not_to eq 1
+    end
+  end
 end


### PR DESCRIPTION
## WHY
Sometimes we want to use `FieldMaskParser::Node#==`.

## WHAT
Add `FieldMaskParser::Node#==`